### PR TITLE
Bump async version to 1.4.2 to allow running strict.

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "async": "^0.1.3"
+    "async": "^1.4.2"
   },
   "devDependencies": {
     "tap": "~0.4.0"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "dependencies": {
-    "async": "~0.1.22"
+    "async": "^0.1.3"
   },
   "devDependencies": {
     "tap": "~0.4.0"


### PR DESCRIPTION
To fix: https://github.com/kesla/async-replace/issues/3